### PR TITLE
Add functionality to fetch top 3 employees by store profit

### DIFF
--- a/src/main/java/com/codefusion/wasbackend/user/controller/UserController.java
+++ b/src/main/java/com/codefusion/wasbackend/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.codefusion.wasbackend.user.controller;
 import com.codefusion.wasbackend.product.dto.ProductDTO;
 import com.codefusion.wasbackend.resourceFile.dto.ResourceFileDTO;
 import com.codefusion.wasbackend.resourceFile.service.ResourceFileService;
+import com.codefusion.wasbackend.user.dto.EmployeeProfitDTO;
 import com.codefusion.wasbackend.user.dto.UserDTO;
 import com.codefusion.wasbackend.user.model.UserEntity;
 import com.codefusion.wasbackend.user.service.UserService;
@@ -47,6 +48,11 @@ public class UserController {
     @GetMapping("/allUser")
     public ResponseEntity<List<UserDTO>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @GetMapping("/top3EmployeesByStoreProfit")
+    public ResponseEntity<List<EmployeeProfitDTO>> getTop3EmployeesByStoreProfit() {
+        return ResponseEntity.ok(userService.getTop3EmployeesByStoreProfit());
     }
 
     /**

--- a/src/main/java/com/codefusion/wasbackend/user/dto/EmployeeProfitDTO.java
+++ b/src/main/java/com/codefusion/wasbackend/user/dto/EmployeeProfitDTO.java
@@ -1,0 +1,14 @@
+package com.codefusion.wasbackend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class EmployeeProfitDTO {
+    private String name;
+    private String surname;
+    private double totalProfit;
+}

--- a/src/main/java/com/codefusion/wasbackend/user/repository/UserRepository.java
+++ b/src/main/java/com/codefusion/wasbackend/user/repository/UserRepository.java
@@ -31,6 +31,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query("SELECT u FROM UserEntity u WHERE u.id = :id AND u.isDeleted = false")
     Optional<UserEntity> findById (@Param("id") Long id);
 
+    @Query("SELECT u FROM UserEntity u JOIN u.account a JOIN a.roles r WHERE r = 'EMPLOYEE'")
+    List<UserEntity> findAllEmployees();
 
     /**
      * Retrieves a user entity based on the ID of the store they are associated with and the specified roles.


### PR DESCRIPTION
A new HTTP GET endpoint /top3EmployeesByStoreProfit has been added to the UserController to support fetching of the top 3 employees by their store profit. A corresponding query method was added to UserRepository to find all employees. A service function was added in UserService for the computation of the total profit made by each employee and selecting the top 3 employees. EmployeeProfitDTO was created to hold the information of the employee and their total profit.