### PR TITLE
Update getTop5MostProfitableProducts method to include sorting option

### DIFF
--- a/src/main/java/com/codefusion/wasbackend/store/controller/StoreController.java
+++ b/src/main/java/com/codefusion/wasbackend/store/controller/StoreController.java
@@ -91,10 +91,13 @@ public class StoreController {
      * @return a ResponseEntity containing a list of the top 5 most profitable ProductDto objects
      */
     @GetMapping("/{storeId}/top5MostProfitableProducts")
-    public ResponseEntity<List<ReturnStoreDTO.ProductDto>> getTop5MostProfitableProducts(@PathVariable Long storeId) {
-        List<ReturnStoreDTO.ProductDto> topProducts = storeService.getTop5MostProfitableProducts(storeId);
-        return ResponseEntity.ok(topProducts);
+    public ResponseEntity<List<ReturnStoreDTO.ProductDto>> getTop5MostProfitableProducts(
+            @PathVariable Long storeId,
+            @RequestParam(required = false, defaultValue = "true") boolean top) {
+        List<ReturnStoreDTO.ProductDto> products = storeService.getTop5MostProfitableProducts(storeId, top);
+        return ResponseEntity.ok(products);
     }
+
 
 
     /**

--- a/src/main/java/com/codefusion/wasbackend/store/service/StoreService.java
+++ b/src/main/java/com/codefusion/wasbackend/store/service/StoreService.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class StoreService extends BaseService<StoreEntity, StoreDTO, StoreRepository> {
@@ -107,16 +108,23 @@ public class StoreService extends BaseService<StoreEntity, StoreDTO, StoreReposi
     }
 
     @Transactional(readOnly = true)
-    public List<ReturnStoreDTO.ProductDto> getTop5MostProfitableProducts(Long storeId) {
+    public List<ReturnStoreDTO.ProductDto> getTop5MostProfitableProducts(Long storeId, boolean top) {
         StoreEntity storeEntity = repository.findById(storeId)
                 .orElseThrow(() -> new RuntimeException("Store not found"));
 
-        return storeEntity.getProducts().stream()
-                .sorted(Comparator.comparingDouble(ProductEntity::getProfit).reversed())
+        Stream<ProductEntity> sortedStream = storeEntity.getProducts().stream()
+                .sorted(Comparator.comparingDouble(ProductEntity::getProfit));
+
+        if (top) {
+            sortedStream = sortedStream.sorted(Comparator.comparingDouble(ProductEntity::getProfit).reversed());
+        }
+
+        return sortedStream
                 .limit(5)
                 .map(StoreHelper::convertToProductDto)
                 .collect(Collectors.toList());
     }
+
 
 
 

--- a/src/main/java/com/codefusion/wasbackend/transaction/service/TransactionService.java
+++ b/src/main/java/com/codefusion/wasbackend/transaction/service/TransactionService.java
@@ -4,7 +4,6 @@ import com.codefusion.wasbackend.base.utils.ProcessUploadFileService;
 import com.codefusion.wasbackend.notification.service.NotificationService;
 import com.codefusion.wasbackend.product.repository.ProductRepository;
 import com.codefusion.wasbackend.resourceFile.dto.ResourceFileDTO;
-import com.codefusion.wasbackend.store.repository.StoreRepository;
 import com.codefusion.wasbackend.transaction.dto.DailyTransactionTotalDTO;
 import com.codefusion.wasbackend.transaction.dto.ReturnTransactionDTO;
 import com.codefusion.wasbackend.transaction.dto.TransactionDTO;


### PR DESCRIPTION
The getTop5MostProfitableProducts method in the StoreService class has been updated to accept a boolean argument for sorting. This allows the caller to decide if they want the products sorted in ascending or descending order based on profit. Additionally, the call to StoreRepository in TransactionService has been removed as it was not being used.